### PR TITLE
Extensiones de CUIT II

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Plataforma | Estado
 
 ## Instalación
 ```
-Install-Package Pixelario.CUIT -Version 0.7.0
+Install-Package Pixelario.CUIT -Version 0.8.0
 ```
 
 ## Modo de uso
@@ -107,6 +107,13 @@ var cuit = CUIT.Complete(
 Puede filtrar CUITs validos de un IEnumerable 
 ```c#
 var cuitsValidos = listaDeCUITs.OnlyValid().ToList();
+
+```
+
+### RangeDocumento
+Puede filtrar CUITs de un IEnumerable por un rango de números de documento.
+```c#
+var cuits = listaDeCUITs.RangeDocumento(27001001, 10).ToList();
 
 ```
 

--- a/demos/Pixelario.CUIT.Demos.PrimerDemo/Program.cs
+++ b/demos/Pixelario.CUIT.Demos.PrimerDemo/Program.cs
@@ -24,10 +24,14 @@ namespace Pixelario.CUIT.Demos.PrimerDemo
                 listaDeCUITs.Add(CreateRandomCUIT());                
             }
             var listaDeCUITsUnicos = listaDeCUITs.GroupBy(c => c).Select(c=>c.Key).ToList();
-            Console.WriteLine(string.Format("Fueron generados {0} CUITs aleatorios, solo {1} fueron distintos y solo {2} fueron válidos.",
-                listaDeCUITs.Count,
-                listaDeCUITsUnicos.Count,
-                listaDeCUITsUnicos.OnlyValid().Count()));
+            Console.WriteLine(string.Format("Fueron generados {0} CUITs aleatorios.",
+                listaDeCUITs.Count));
+             Console.WriteLine(string.Format("{0} son distintos.",
+                listaDeCUITsUnicos.Count));
+            Console.WriteLine(string.Format("{0} son válidos.",
+               listaDeCUITsUnicos.OnlyValid().Count()));
+            Console.WriteLine(string.Format("{0} son válidos y tienen número de documento entre 27000000 y 27000009.",
+                listaDeCUITsUnicos.OnlyValid().RangeDocumento(27000000,9).Count()));
 
         }
 

--- a/src/CUIT/CUIT.cs
+++ b/src/CUIT/CUIT.cs
@@ -29,7 +29,7 @@ namespace Pixelario.CUIT
             }
         }
         private bool _isValid = true;
-        private ComponentesStruct Componentes { get; set; }
+        public ComponentesStruct Componentes { get; private set; }
         public CUIT(string cuit)
         {
             if (cuit.Length < 9 ||

--- a/src/CUIT/CUIT.csproj
+++ b/src/CUIT/CUIT.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>Pixelario.CUIT</RootNamespace>
     <AssemblyName>Pixelario.CUIT</AssemblyName>
-    <Version>0.7.0</Version>
+    <Version>0.8.0</Version>
     <Authors>Ing. Bernardo Raskovsky</Authors>
     <Company>Pixelario</Company>
     <Title>CUIT</Title>
@@ -12,7 +12,8 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/pixelario/CUIT</RepositoryUrl>
     <PackageTags>CUIT, Argentina</PackageTags>
-    <PackageReleaseNotes>* Nueva extension para filtrar solo CUIT validos de un IEnumerable</PackageReleaseNotes>
+    <PackageReleaseNotes>* Nueva extension para filtrar CUIT de un IEnumerable por un rango de números de documento.
+* Mejoras en la visibilidad de las propiedades internas y la clase</PackageReleaseNotes>
     <PackageProjectUrl>http://www.pixelario.com.ar</PackageProjectUrl>
     <PackageIcon>CUIT.png</PackageIcon>
     <PackageIconUrl />

--- a/src/CUIT/Extensions/RangeDocumento.cs
+++ b/src/CUIT/Extensions/RangeDocumento.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Pixelario.CUIT.Extensions
+{
+    public static partial class EnumerableMethods
+    {
+        public static IEnumerable<CUIT> RangeDocumento(this IEnumerable<CUIT> input,
+            int start, int count)
+        {
+            var end = start + count;
+            if (input == null)
+            {
+                throw new ArgumentNullException();
+            }
+            foreach (var cuit in input)
+            {
+
+                if (cuit.Componentes.NumeroDeDocumento >= start && 
+                    cuit.Componentes.NumeroDeDocumento <= end)
+                {
+                    yield return cuit;
+                }
+            }
+        }
+    }
+}

--- a/test/CUIT.UniTests/RangeDocumento.cs
+++ b/test/CUIT.UniTests/RangeDocumento.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+using Pixelario.CUIT.Extensions;
+
+namespace Pixelario.CUIT.UniTests
+{
+    public class RangeDocumento
+    {        
+        [Fact]
+        public void GetBetween27001001And27001999()
+        {
+            var input = new List<CUIT>() { 
+                new CUIT("20270010017"),
+                new CUIT("27230010012"),
+                new CUIT("23270019990"),
+                new CUIT("23270020004")
+            };
+            Assert.Equal(2, input.RangeDocumento(27001001, 998).Count());
+        }
+
+    }
+}


### PR DESCRIPTION
Nueva extensión RangeDocumento filtra CUIT's de un IEnumerable<CUIT> por un rango de números de documento.